### PR TITLE
KAA-936 Downgrade cc3200-sdk to 1.1.0

### DIFF
--- a/client/client-multi/client-c/nix/cc3200-sdk/default.nix
+++ b/client/client-multi/client-c/nix/cc3200-sdk/default.nix
@@ -2,11 +2,11 @@
 }:
 stdenv.mkDerivation rec {
 
-  name = "cc3200-sdk-1.2.0";
+  name = "cc3200-sdk-1.1.0";
 
   src = requireFile {
-    name = "CC3200SDK-1.2.0-windows-installer.exe";
-    sha256 = "1wdm52n7mx5w57l48gdl8387nsn2vgq3pwxy9z5zc7v9k16zcldh";
+    name = "CC3200SDK-1.1.0-windows-installer.exe";
+    sha256 = "1m5yjp2wjpgbjkq200b700gmz974519fw7rxby8cfxirkzknicw1";
     url = "http://www.ti.com/tool/cc3200sdk";
   };
 


### PR DESCRIPTION
Demos don't currently support 1.2.0. There is also a warning on 1.2.0, so we should switch back to 1.1.0 temporarily.
